### PR TITLE
fix: pin generated project dependencies

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import { create } from "sv";
 import executePrompts from "./executePrompts.js";
 import getLatestDependencyVersion from "./helpers/getLatestDependencyVersion.js";
 import install from "./helpers/install.js";
-import { Packages } from "./types.js";
+import { Packages, PackageVersions } from "./types.js";
 import AddAutoimportCommand from "./commands/add-autoimport/AddAutoimportCommand.js";
 import AddBoilerplateCommand from "./commands/add-boilerplate/AddBoilerplateCommand.js";
 import addToPackageJson from "./helpers/addToPackageJson.js";
@@ -62,12 +62,12 @@ if (optionalFeatures.includes("eslintAndPrettier")) {
 
 const devDependencies: PackageJson["devDependencies"] = {
   [Packages.QUAFF]: await getLatestDependencyVersion(Packages.QUAFF),
-  [Packages.MATERIAL_SYMBOLS]: await getLatestDependencyVersion(Packages.MATERIAL_SYMBOLS),
-  [Packages.FONTSOURCE_ROBOTO]: await getLatestDependencyVersion(Packages.FONTSOURCE_ROBOTO),
+  [Packages.MATERIAL_SYMBOLS]: PackageVersions.MATERIAL_SYMBOLS,
+  [Packages.FONTSOURCE_ROBOTO]: PackageVersions.FONTSOURCE_ROBOTO,
 };
 
 if (cssPreprocessor === "scss") {
-  devDependencies[Packages.SASS] = await getLatestDependencyVersion(Packages.SASS);
+  devDependencies[Packages.SASS] = PackageVersions.SASS;
 }
 
 await addToPackageJson(projectDir, {

--- a/src/commands/add-autoimport/AddAutoimportCommand.ts
+++ b/src/commands/add-autoimport/AddAutoimportCommand.ts
@@ -1,7 +1,6 @@
 import { join } from "path";
 import { readFile, writeFile } from "fs/promises";
-import getLatestDependencyVersion from "../../helpers/getLatestDependencyVersion.js";
-import { Packages } from "../../types.js";
+import { Packages, PackageVersions } from "../../types.js";
 import addToPackageJson from "../../helpers/addToPackageJson.js";
 import pathExists from "../../helpers/pathExists.js";
 import mkdirp from "../../helpers/mkdirp.js";
@@ -58,9 +57,7 @@ export default class AddAutoimportCommand {
   async execute() {
     await addToPackageJson(this.projectDir, {
       devDependencies: {
-        [Packages.SVELTEKIT_AUTOIMPORT]: await getLatestDependencyVersion(
-          Packages.SVELTEKIT_AUTOIMPORT
-        ),
+        [Packages.SVELTEKIT_AUTOIMPORT]: PackageVersions.SVELTEKIT_AUTOIMPORT,
       },
     });
 

--- a/src/helpers/getLatestDependencyVersion.ts
+++ b/src/helpers/getLatestDependencyVersion.ts
@@ -11,15 +11,10 @@ export default async function getLatestDependencyVersion(packageName: string): P
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 
-  const packageData = (await response.json()) as PackageData;
-  let { version } = packageData;
+  const { version } = (await response.json()) as PackageData;
 
   if (!version || typeof version !== "string") {
     throw new Error(`could not find a valid version for dependency "${packageName}"`);
-  }
-
-  if (!version.startsWith("^")) {
-    version = "^" + version;
   }
 
   return version;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,10 @@ export enum Packages {
   MATERIAL_SYMBOLS = "material-symbols",
   SVELTEKIT_AUTOIMPORT = "sveltekit-autoimport",
 }
+
+export enum PackageVersions {
+  SASS = "1.101.0",
+  FONTSOURCE_ROBOTO = "5.2.10",
+  MATERIAL_SYMBOLS = "0.45.6",
+  SVELTEKIT_AUTOIMPORT = "1.8.2",
+}


### PR DESCRIPTION
This PR pins the dependency versions (except that of Quaff itself) of newly created projects. This is to make `create-quaff` more stable and also to avoid issues with minimum release age constraints.